### PR TITLE
Include groups definition in the LDIF file

### DIFF
--- a/src/main/resources/test.ldif
+++ b/src/main/resources/test.ldif
@@ -1,13 +1,44 @@
+###########################################################################
+# Change LDAP schema to support the memberOf attribute
+# (see note below)
+dn: m-oid=1.2.840.113556.1.4.222, ou=attributetypes, cn=other, ou=schema
+changetype: add
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.2.840.113556.1.4.222
+m-name: memberOf
+m-equality: caseIgnoreMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.15
+m-singleValue: FALSE
+
+dn: m-oid=1.2.840.113556.1.5.6, ou=objectclasses, cn=other, ou=schema
+changetype: add
+objectclass: metaObjectClass
+objectclass: metaTop
+objectclass: top
+m-oid: 1.2.840.113556.1.5.6
+m-name: memberOfGroups
+m-supObjectClass: top
+m-typeObjectClass: AUXILIARY
+m-may: memberOf
+
+###########################################################################
+# USERS
 dn: uid=test1,ou=users,ou=system
 changetype: add
 objectClass: inetOrgPerson
 objectClass: organizationalPerson
 objectClass: person
 objectClass: top
+objectClass: memberOfGroups
 userid: test1
 userPassword: test1
+mail: test1@example.com
 sn: test1
 cn: test1
+memberOf: cn=TeamA,ou=groups,ou=system
+memberOf: cn=TeamB,ou=groups,ou=system
 
 dn: uid=test2,ou=users,ou=system
 changetype: add
@@ -15,7 +46,40 @@ objectClass: inetOrgPerson
 objectClass: organizationalPerson
 objectClass: person
 objectClass: top
+objectClass: memberOfGroups
 userid: test2
 userPassword: test2
+mail: test2@example.com
 sn: test2
 cn: test2
+memberOf: cn=TeamA,ou=groups,ou=system
+
+###########################################################################
+# GROUPS
+dn: cn=TeamA,ou=groups,ou=system
+changetype: add
+objectClass: groupOfNames
+cn: TeamA
+description: First User Group
+member: uid=test1,ou=users,ou=system
+member: uid=test2,ou=users,ou=system
+
+dn: cn=TeamB,ou=groups,ou=system
+changetype: add
+objectClass: groupOfNames
+cn: TeamB
+description: Second User Group
+member: uid=test1,ou=users,ou=system
+
+
+###
+### Note on the memberOf attribute:
+# This attribute is enabled by some LDAP servers (including AD) to identify the groups to which a user belongs.
+# Apache Directory planned to implement it as a virtual attribute, but it has not released
+# a new version for some time.
+#
+# http://mail-archives.apache.org/mod_mbox/directory-users/201305.mbox/%3C519A54B1.5070200@gmail.com%3E
+# http://mail-archives.apache.org/mod_mbox/directory-dev/201609.mbox/%3CJIRA.12648490.1369078616000.588923.1474028122553@Atlassian.JIRA%3E
+#
+# In this LDIF we mock the required class/attribute to properly use the Group and MemberOf features
+###


### PR DESCRIPTION
Include groups definition in the LDIF file, and add the memberOf attribute to the user schema.

The change allows this dummy server to be used in test cases that require group membership.